### PR TITLE
Feature: -days option for leasing more than a day

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ On start of the container your `openrc.sh` will be automatically sourced. Be sur
 ./create_instance.sh
 ```
 
+By default the leasing lasts within a day. If longer leasing day is needed,
+```bash
+./create_instance.sh -h
+ Lease a Chameleon node
+ USAGE: create_instance.sh [OPTIONS]
+    [OPTIONS]
+    -help         Print help
+    -days         Number of days to lease
+./create_instance.sh -days 7
+```
+
 You can change some defaults by setting environment variables, e.g.:
 ```bash
 export IMAGE='CC-Ubuntu18.04-CUDA10'

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ On start of the container your `openrc.sh` will be automatically sourced. Be sur
 
 By default the leasing lasts within a day. If longer leasing day is needed,
 ```bash
-./create_instance.sh -h
+./create_instance.sh -help
  Lease a Chameleon node
  USAGE: create_instance.sh [OPTIONS]
     [OPTIONS]

--- a/create_instance.sh
+++ b/create_instance.sh
@@ -12,7 +12,7 @@ while [[ $# -gt 0 ]]
 do
   key="$1"
   case $key in
-    -h)
+    -help)
     help
     exit 0
     ;;


### PR DESCRIPTION
Users now can use `-days` option to specify how long they want to lease a node.